### PR TITLE
Functional Splitter Completed

### DIFF
--- a/src/motion/CMakeLists.txt
+++ b/src/motion/CMakeLists.txt
@@ -46,6 +46,7 @@ target_include_directories(motion #Library name, in this case the package name
 #Create an executable
 add_executable(multiplexer src/multiplexer.cpp)
 add_executable(driver_upper src/driver_upper.cpp)
+add_executable(splitter src/splitter.cpp)
 
 #DBG
 add_executable(dummy src/dummy.cpp)
@@ -54,12 +55,14 @@ add_executable(dummy src/dummy.cpp)
 ament_target_dependencies(multiplexer rclcpp std_msgs telebot_interfaces)
 ament_target_dependencies(driver_upper rclcpp std_msgs telebot_interfaces dynamixel_sdk)
 ament_target_dependencies(dummy rclcpp telebot_interfaces)
+ament_target_dependencies(splitter rclcpp telebot_interfaces)
 
 #Not really sure why this is needed but it is, just add ur executables into the list
 install(TARGETS
   multiplexer
   driver_upper
   dummy
+  splitter
   #<executable>
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
@@ -71,6 +74,7 @@ install(TARGETS
 target_link_libraries(multiplexer motion)
 target_link_libraries(driver_upper motion)
 target_link_libraries(dummy motion)
+target_link_libraries(splitter motion)
 #Idk what this does either
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/src/motion/config/splitter_config.yaml
+++ b/src/motion/config/splitter_config.yaml
@@ -1,0 +1,40 @@
+/splitter:
+  ros__parameters:
+    motor_ids:
+      lower_ids:
+      - 50
+      - 51
+      - 63
+      upper_ids:
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 17
+      - 21
+      - 22
+      - 23
+      - 24
+      - 30
+      - 31
+    qos_overrides:
+      /parameter_events:
+        publisher:
+          depth: 1000
+          durability: volatile
+          history: keep_last
+          reliability: reliable
+    use_sim_time: false
+

--- a/src/motion/src/splitter.cpp
+++ b/src/motion/src/splitter.cpp
@@ -1,0 +1,66 @@
+#include <vector>
+#include <algorithm>
+
+#include "rclcpp/rclcpp.hpp"
+#include "telebot_interfaces/msg/motor_goal.hpp"
+#include "telebot_interfaces/msg/motor_goal_list.hpp"
+#include "motion/topic_prefixes.hpp"
+
+using std::vector;
+using std::find;
+using std::placeholders::_1;
+
+using rclcpp::Node;
+using telebot_interfaces::msg::MotorGoal;
+using telebot_interfaces::msg::MotorGoalList;
+using rclcpp::Publisher;
+using rclcpp::Subscription;
+
+class Splitter : public Node {
+public:
+    Splitter() : Node("splitter") {
+        this->declare_parameter("motor_ids.upper_ids", vector<int>());
+        this->declare_parameter("motor_ids.lower_ids", vector<int>());
+
+        this->upperPublisher_ = this->create_publisher<MotorGoalList>(TopicPrefixes::getPrivateTopicName("upper_goals"), 10);
+        this->lowerPublisher_ = this->create_publisher<MotorGoalList>(TopicPrefixes::getPrivateTopicName("lower_goals"), 10);
+        this->sourceSubscription_ = this->create_subscription<MotorGoalList>(TopicPrefixes::getPrivateTopicName("goals"), 10, std::bind(&Splitter::goalCallback, this, _1));
+    }
+private:
+    void goalCallback(const MotorGoalList &goals) const {
+        const auto upperIds = this->get_parameter("motor_ids.upper_ids").as_integer_array();
+        const auto lowerIds = this->get_parameter("motor_ids.lower_ids").as_integer_array();
+
+        // Messages to be sent to corresponding topics
+        MotorGoalList upperGoals = MotorGoalList();
+        MotorGoalList lowerGoals = MotorGoalList();
+
+        // Iterate through each goal and sort them into upperGoals,lowerGoals, or discard
+        for (auto it = goals.motor_goals.begin(); it != goals.motor_goals.end(); ++it) {
+            if (find(upperIds.begin(), upperIds.end(), it->motor_id) != upperIds.end()) {
+                upperGoals.motor_goals.push_back(*it);
+            }
+            else if (find(lowerIds.begin(), lowerIds.end(), it->motor_id) != lowerIds.end()) {
+                lowerGoals.motor_goals.push_back(*it);
+            }
+            else {
+                RCLCPP_WARN(this->get_logger(), "Invalid Motor ID: %d! Discarding Goal...", it->motor_id);
+            }
+        }
+
+        // Publish sorted messages to be checked by safety
+        this->upperPublisher_->publish(upperGoals);
+        this->lowerPublisher_->publish(lowerGoals);
+    }
+
+    Publisher<MotorGoalList>::SharedPtr upperPublisher_;
+    Publisher<MotorGoalList>::SharedPtr lowerPublisher_;
+    Subscription<MotorGoalList>::SharedPtr sourceSubscription_;
+};
+
+int main(int argc, char *argv[]) {
+    rclcpp::init(argc, argv);
+    rclcpp::spin(std::make_shared<Splitter>());
+    rclcpp::shutdown();
+    return 0;
+}


### PR DESCRIPTION
The splitter node is functional. The associated config file `splitter_config.yaml` uses made up motor IDs for the lower motors as I don't know what their IDs are, but these can be easily changed.

I branched off of the `motion` branch, so this pull request will merge my changes back into the `motion` branch.

Closes #5 